### PR TITLE
Improve compatibility with Linux 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.mod
 *.mod.c
 *.o
+*.o.d
 
 /*.tar.gz
 /build

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -87,11 +87,11 @@ KERNELARCH := $(subst i386,x86,$(subst x86_64,x86,$(IMPORTED_ARCH)))
 # Starting 2.6.28, most include/asm headers were moved to arch/<arch>/include/asm
 REAL_KERNELSRC_INCLUDE_ASM := $(shell for p in $(CNXT_KERNELSRC)/include2/asm $(REAL_KERNELSRC)/arch/$(KERNELARCH)/include/asm; do if test -e $${p}; then echo $${p}; exit 0; fi; done; for p in arch/$(KERNELARCH)/include/asm include/asm; do if test -e $(CNXT_KERNELSRC)/$${p}; then echo $(REAL_KERNELSRC)/$${p}; exit 0; fi; done;)
 
-ifeq ($(CNXTTARGET),hsf)
+#ifeq ($(CNXTTARGET),hsf)
 REPLACE_HDA := true
-else
-REPLACE_HDA := false
-endif
+#else
+#REPLACE_HDA := false
+#endif
 
 # Configure compiler (on some systems, kgcc must be used to compile kernel code)
 #
@@ -159,7 +159,7 @@ ifeq ($(ON_BUILD_SYSTEM)-$(CONFIG_SND_HDA_INTEL),no-)
 CONFIG_SND_HDA_INTEL=$(shell modprobe -n snd-hda-intel > /dev/null 2>&1 && echo y || echo n)
 endif
 
-MODULAR_HDA := $(shell test -e  ${REAL_KERNELSRC}/include/sound/hda_codec.h && echo yes || echo no)
+#MODULAR_HDA := $(shell test -e  ${REAL_KERNELSRC}/include/sound/hda_codec.h && echo yes || echo no)
 
 else
 KO= o

--- a/modules/cnxthwhda_common.c
+++ b/modules/cnxthwhda_common.c
@@ -124,7 +124,7 @@ static int cnxthwhda_setsyms (void **ppInterfaceFuncs);
 	snprintf(pDevNode->hwInstName, sizeof(pDevNode->hwInstName), "HDA-%08x:%08x-%u",
 			OsHdaCodecGetVendorId(pHdaOsHal), OsHdaCodecGetSubsystemId(pHdaOsHal), OsHdaCodecGetAddr(pHdaOsHal));
 	pDevNode->hwType = CNXTHWHDA_TYPE;
-	pDevNode->hwIf = GetHwFuncs();
+	// pDevNode->hwIf = GetHwFuncs();
 	pDevNode->pmControl = cnxthw_DevMgrPMControl;
 	pDevNode->osPageOffset = PAGE_OFFSET;
 

--- a/modules/cnxthwpci_common.c
+++ b/modules/cnxthwpci_common.c
@@ -83,7 +83,7 @@ static int __devinit cnxthwpci_probe (struct pci_dev *pdev,
 	    	pdev->vendor, pdev->device, pdev->subsystem_vendor, pdev->subsystem_device);
 #ifdef CNXTHWPCI_TYPE
     pDevNode->hwType = CNXTHWPCI_TYPE;
-    pDevNode->hwIf = GetHwFuncs();
+    // pDevNode->hwIf = GetHwFuncs();
 #endif
     pDevNode->pmControl = cnxthw_DevMgrPMControl;
     pDevNode->osPageOffset = PAGE_OFFSET;

--- a/modules/cnxthwusb_common.c
+++ b/modules/cnxthwusb_common.c
@@ -326,7 +326,7 @@ static int __devinit cnxthwusb_probe(struct usb_interface *intf,
 	    USB_BYTEORDER16(pUsbDevice->descriptor.idVendor), USB_BYTEORDER16(pUsbDevice->descriptor.idProduct));
 #ifdef CNXTHWUSB_TYPE
     pDevNode->hwType = CNXTHWUSB_TYPE;
-    pDevNode->hwIf = GetHwFuncs();
+    // pDevNode->hwIf = GetHwFuncs();
 #endif
     pDevNode->pmControl = cnxthw_DevMgrPMControl;
 	pDevNode->osPageOffset = PAGE_OFFSET;

--- a/modules/imported/include/osuniqredef.h
+++ b/modules/imported/include/osuniqredef.h
@@ -239,7 +239,7 @@
 #define RPT_Write _OSUNIQDEF(RPT_Write)
 #define ulTraceMask _OSUNIQDEF(ulTraceMask)
 #define ulLogThread _OSUNIQDEF(ulLogThread)
-#define GetSOARLibInterface _OSUNIQDEF(GetSOARLibInterface)
+// #define GetSOARLibInterface _OSUNIQDEF(GetSOARLibInterface)
 #define cnxt_serial_add _OSUNIQDEF(cnxt_serial_add)
 #define cnxt_serial_remove _OSUNIQDEF(cnxt_serial_remove)
 

--- a/modules/imported/makeflags.mak
+++ b/modules/imported/makeflags.mak
@@ -1,3 +1,3 @@
-IMPORTED_ARCH ?= $(shell uname -i)
+IMPORTED_ARCH ?= $(shell uname -m)
 
 include $(TOP)/modules/imported/makeflags-$(IMPORTED_ARCH).mak

--- a/modules/mod_soar.c
+++ b/modules/mod_soar.c
@@ -10,9 +10,9 @@
 #include "osservices.h"
 #include "comtypes.h"
 
-PVOID GetSOARLibInterface(void);
+// PVOID GetSOARLibInterface(void);
 
-EXPORT_SYMBOL_NOVERS(GetSOARLibInterface);
+// EXPORT_SYMBOL_NOVERS(GetSOARLibInterface);
 
 MODULE_AUTHOR("Copyright (C) 1996-2001 Conexant Systems Inc.");
 MODULE_DESCRIPTION("HSF module for SmartDAA(tm) devices");


### PR DESCRIPTION
However, 639ca0d will be revised.
- Needs to check whether `ktime_t` exists, needs to get precision issue fixed